### PR TITLE
Make Client stateless, add Connection class for querying

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,55 +123,51 @@ export class Connection {
   }
 
   async execute(query: string): Promise<ExecutedQuery> {
-    try {
-      const startTime = new Date().getTime()
-      const saved = await this.postJSON<QueryExecuteResponse>(
-        `${this.client.credentials.mysqlAddress}/psdb.v1alpha1.Database/Execute`,
-        {
-          query: query,
-          session: this.session
-        }
-      )
-      const endTime = new Date().getTime()
-      const elapsedTime = endTime - startTime
-      if (saved.ok && !saved.ok.error) {
-        const body = saved.ok
-        const result = body.result
-        const rows = result ? parse(result) : null
-        const headers = result?.fields?.map((f) => f.name)
-
-        this.session = body.session
-
-        // Transform response into something we understand, this matches our
-        // console's `QueryConsole` response format.
-        return {
-          headers,
-          rows,
-          size: rows.length,
-          statement: query,
-          time: elapsedTime
-        }
-      } else if (saved.ok && saved.ok.error) {
-        return {
-          statement: query,
-          errorMessage: saved.ok.error.message,
-          time: elapsedTime
-        }
-      } else {
-        let errorCode: string | null = null
-        if (saved.err instanceof ClientError) {
-          errorCode = saved.err.body.code
-        }
-
-        return {
-          statement: query,
-          errorCode: errorCode,
-          errorMessage: apiMessage(saved.err),
-          time: elapsedTime
-        }
+    const startTime = new Date().getTime()
+    const saved = await this.postJSON<QueryExecuteResponse>(
+      `${this.client.credentials.mysqlAddress}/psdb.v1alpha1.Database/Execute`,
+      {
+        query: query,
+        session: this.session
       }
-    } catch (e) {
-      throw e
+    )
+    const endTime = new Date().getTime()
+    const elapsedTime = endTime - startTime
+    if (saved.ok && !saved.ok.error) {
+      const body = saved.ok
+      const result = body.result
+      const rows = result ? parse(result) : null
+      const headers = result?.fields?.map((f) => f.name)
+
+      this.session = body.session
+
+      // Transform response into something we understand, this matches our
+      // console's `QueryConsole` response format.
+      return {
+        headers,
+        rows,
+        size: rows.length,
+        statement: query,
+        time: elapsedTime
+      }
+    } else if (saved.ok && saved.ok.error) {
+      return {
+        statement: query,
+        errorMessage: saved.ok.error.message,
+        time: elapsedTime
+      }
+    } else {
+      let errorCode: string | null = null
+      if (saved.err instanceof ClientError) {
+        errorCode = saved.err.body.code
+      }
+
+      return {
+        statement: query,
+        errorCode: errorCode,
+        errorMessage: apiMessage(saved.err),
+        time: elapsedTime
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request takes away the management of sessions from the Client and pushes that responsibility down to the new `Connection` class. This way, we can have multiple connections per-client, with client inherently becoming stateless. If a connection needs to be re-used, then users can query directly from the connection itself and it's session will be persisted across transactions and such.

I also removed the `try/catch` block from `execute`. If something unexpected goes wrong, I think we should bubble that up to the user and let them figure out how they want to handle it. I'm wondering if we should do something for `postJSON` as well, to be honest.