### PR TITLE
Emit null values for SQL NULL results

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -172,7 +172,7 @@ function decodeRow(row: QueryResultRow): Array<string | null> {
   })
 }
 
-function parseColumn(type: string, value: string | null): number | string {
+function parseColumn(type: string, value: string | null): number | string | null {
   if (value === '' || value == null) {
     return value
   }


### PR DESCRIPTION
Don't convert null into the empty string so the caller receives the actual value from the database.