### PR TITLE
Make QuerySession more opaque

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,10 +35,7 @@ export interface QueryResultField {
   columnType?: string | null
 }
 
-export interface QuerySession {
-  signature: string
-  vitessSession: any
-}
+export type QuerySession = unknown
 
 interface VitessError {
   message: string


### PR DESCRIPTION
We intentionally don't want or need to surface types within the
QuerySession type. We likely will change what this is and it's intended
to simply be echo'd back, whatever it is. So converting it to simply a
type alias for `unknown` seems to be the right move.

First TypeScript ever btw. Please tell me if I have no idea what I'm doing.