### PR TITLE
Lower build target to 2020

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
+    "module": "es2020",
+    "target": "es2020",
     "strict": false,
     "declaration": true,
     "outDir": "dist",


### PR DESCRIPTION
The esnext target is a pointer to future versions so set a fixed output target version.