### PR TITLE
Support database URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ const results = await conn.execute('select 1 from dual where 1=?', [1])
 console.log(results)
 ```
 
+### Database URL
+
+A single database URL value can be used to configure the `host`, `username`, and `password` values.
+
+```ts
+import { connect } from '@planetscale/database'
+
+const config = {
+  url: process.env['DATABASE_URL'] || 'mysql://user:pass@aws.connect.psdb.cloud'
+}
+
+const conn = await connect(config)
+```
+
 ### Connection factory
 
 Use the `Client` connection factory class to create fresh connections for each transaction or web request handler.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -22,6 +22,24 @@ setGlobalDispatcher(mockAgent)
 const mockPool = mockAgent.get(mockHost)
 const mockSession = 42
 
+describe('config', () => {
+  test('parses database url', async () => {
+    const mockResponse = {
+      session: mockSession,
+      result: { fields: [], rows: [] }
+    }
+
+    mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
+      expect(opts.headers['authorization']).toEqual(`Basic ${btoa('someuser:password')}`)
+      return mockResponse
+    })
+
+    const connection = connect({ fetch, url: 'mysql://someuser:password@example.com' })
+    const got = await connection.execute('SELECT 1 from dual;')
+    expect(got).toBeDefined()
+  })
+})
+
 describe('execute', () => {
   test('it properly returns and decodes a select query', async () => {
     const mockResponse = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,10 @@ export interface ExecutedQuery {
 }
 
 export interface Config {
-  username: string
-  password: string
-  host: string
+  url?: string
+  username?: string
+  password?: string
+  host?: string
   fetch?: (input: string, init?: ReqInit) => Promise<Pick<Response, 'ok' | 'json' | 'status' | 'statusText' | 'text'>>
   format?: (query: string, args: any) => string
 }
@@ -52,11 +53,8 @@ interface QueryResultField {
   orgName?: string | null
 
   columnLength?: number | null
-
   charset?: number | null
-
   flags?: number | null
-
   columnType?: string | null
 }
 
@@ -96,11 +94,19 @@ export class Connection {
   private session: QuerySession | null
 
   constructor(config: Config) {
-    if (typeof fetch !== 'undefined') {
-      config = { fetch, ...config }
-    }
-    this.config = config
     this.session = null
+    this.config = { ...config }
+
+    if (typeof fetch !== 'undefined') {
+      this.config.fetch ||= fetch
+    }
+
+    if (config.url) {
+      const url = new URL(config.url)
+      this.config.username = url.username
+      this.config.password = url.password
+      this.config.host = url.hostname
+    }
   }
 
   async refresh(): Promise<boolean> {


### PR DESCRIPTION
Parse a database URL into host, username, and password configuration values. This allows the app to configure a single environment variable rather than three. Closes #26.