### PR TITLE
Define cast return type as any

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ type ReqInit = Pick<RequestInit, 'method' | 'headers'> & {
   body: string
 }
 
-type Row = Record<string, unknown>
+type Row = Record<string, any>
 
 interface VitessError {
   message: string
@@ -232,7 +232,7 @@ function decodeRow(row: QueryResultRow): Array<string | null> {
   })
 }
 
-export function cast(field: Field, value: string | null): number | string | null {
+export function cast(field: Field, value: string | null): any {
   if (value === '' || value == null) {
     return value
   }


### PR DESCRIPTION
Now that a cast function can be provided by the app, we no longer know its possible return types so use the `any` type. Closes #53.