### PR TITLE
Add support for transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,6 @@ const config = {
 
 const conn = connect(config)
 const results = await conn.transaction((tx) => {
-  const statement = `INSERT INTO slotted_counters(record_type, record_id, slot, count)
-    VALUES (branch_count, database_id, RAND() * 100, 1)
-    ON DUPLICATE KEY UPDATE count = count + 1;`
-
   return Promise.all([
     tx.execute('INSERT INTO branches (database_id, name) VALUES (?, ?), [42, "planetscale"]'),
     tx.execute('INSERT INTO slotted_counters(record_type, record_id, slot, count) VALUES (branch_count, database_id, RAND() * 100, 1) ON DUPLICATE KEY UPDATE count = count + 1')

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ const config = {
 const conn = connect(config)
 const results = await conn.transaction(async (tx) => {
   const whenBranch = await tx.execute('INSERT INTO branches (database_id, name) VALUES (?, ?)', [42, "planetscale"])
-  const whenCounter = await tx.execute('INSERT INTO slotted_counters(record_type, record_id, slot, count) VALUES (?, ?, RAND() * 100, 1) ON DUPLICATE KEY UPDATE count = count + 1', [branch_count, database_id])
+  const whenCounter = await tx.execute('INSERT INTO slotted_counters(record_type, record_id, slot, count) VALUES (?, ?, RAND() * 100, 1) ON DUPLICATE KEY UPDATE count = count + 1', ['branch_count', 42])
   return [whenBranch, whenCounter]
 })
 console.log(results)

--- a/README.md
+++ b/README.md
@@ -73,10 +73,9 @@ const config = {
 
 const conn = connect(config)
 const results = await conn.transaction(async (tx) => {
-const whenBranch = await tx.execute('INSERT INTO branches (database_id, name) VALUES (?, ?)', [42, "planetscale"])
-const whenCounter = await tx.execute('INSERT INTO slotted_counters(record_type, record_id, slot, count) VALUES (?, ?, RAND() * 100, 1) ON DUPLICATE KEY UPDATE count = count + 1', [branch_count, database_id])
-
-return [whenBranch, whenCounter]
+  const whenBranch = await tx.execute('INSERT INTO branches (database_id, name) VALUES (?, ?)', [42, "planetscale"])
+  const whenCounter = await tx.execute('INSERT INTO slotted_counters(record_type, record_id, slot, count) VALUES (?, ?, RAND() * 100, 1) ON DUPLICATE KEY UPDATE count = count + 1', [branch_count, database_id])
+  return [whenBranch, whenCounter]
 })
 console.log(results)
 ```

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ const config = {
 const conn = connect(config)
 const results = await conn.transaction(async (tx) => {
   return Promise.all([
-    tx.execute('INSERT INTO branches (database_id, name) VALUES (?, ?), [42, "planetscale"]'),
-    tx.execute('INSERT INTO slotted_counters(record_type, record_id, slot, count) VALUES (branch_count, database_id, RAND() * 100, 1) ON DUPLICATE KEY UPDATE count = count + 1')
+    tx.execute('INSERT INTO branches (database_id, name) VALUES (?, ?)', [42, "planetscale"]),
+    tx.execute('INSERT INTO slotted_counters(record_type, record_id, slot, count) VALUES (?, ?, RAND() * 100, 1) ON DUPLICATE KEY UPDATE count = count + 1', [branch_count, database_id])
   ])
 })
 console.log(results)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ const config = {
 }
 
 const conn = connect(config)
-const results = await conn.transaction((tx) => {
+const results = await conn.transaction(async (tx) => {
   return Promise.all([
     tx.execute('INSERT INTO branches (database_id, name) VALUES (?, ?), [42, "planetscale"]'),
     tx.execute('INSERT INTO slotted_counters(record_type, record_id, slot, count) VALUES (branch_count, database_id, RAND() * 100, 1) ON DUPLICATE KEY UPDATE count = count + 1')

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ const config = {
 
 const conn = connect(config)
 const results = await conn.transaction(async (tx) => {
-  return Promise.all([
-    tx.execute('INSERT INTO branches (database_id, name) VALUES (?, ?)', [42, "planetscale"]),
-    tx.execute('INSERT INTO slotted_counters(record_type, record_id, slot, count) VALUES (?, ?, RAND() * 100, 1) ON DUPLICATE KEY UPDATE count = count + 1', [branch_count, database_id])
-  ])
+const whenBranch = await tx.execute('INSERT INTO branches (database_id, name) VALUES (?, ?)', [42, "planetscale"])
+const whenCounter = await tx.execute('INSERT INTO slotted_counters(record_type, record_id, slot, count) VALUES (?, ?, RAND() * 100, 1) ON DUPLICATE KEY UPDATE count = count + 1', [branch_count, database_id])
+
+return [whenBranch, whenCounter]
 })
 console.log(results)
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,19 @@ export class Client {
   }
 }
 
-type Transaction = Connection
+export type Transaction = Tx
+
+class Tx {
+  private conn: Connection
+
+  constructor(conn: Connection) {
+    this.conn = conn
+  }
+
+  async execute(query: string, args?: object | any[]): Promise<ExecutedQuery> {
+    return this.conn.execute(query, args)
+  }
+}
 
 export class Connection {
   private config: Config
@@ -141,7 +153,8 @@ export class Connection {
   }
 
   async transaction<T>(fn: (tx: Transaction) => Promise<T>): Promise<T> {
-    const tx = new Connection(this.config)
+    const conn = new Connection(this.config) // Create a new connection specifically for the transaction
+    const tx = new Tx(conn)
 
     try {
       await tx.execute('BEGIN')

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,10 @@ export class Client {
     this.config = config
   }
 
+  async transaction<T>(fn: (tx: Transaction) => Promise<T>): Promise<T> {
+    return this.connection().transaction(fn)
+  }
+
   async execute(query: string, args?: object | any[]): Promise<ExecutedQuery> {
     return this.connection().execute(query, args)
   }


### PR DESCRIPTION
This pull request adds support for transactions within the driver. Callers can use this for safely executing transactions that get rolled back after exceptions.

Closes https://github.com/planetscale/database-js/issues/54