### PR TITLE
Remove timezone from sanitized date strings

### DIFF
--- a/__tests__/sanitization.test.ts
+++ b/__tests__/sanitization.test.ts
@@ -57,7 +57,7 @@ describe('sanitization', () => {
     test('formats date values', () => {
       const ts = Date.UTC(2022, 1, 8, 13, 15, 45)
       const query = 'select 1 from user where created_at > ?'
-      const expected = "select 1 from user where created_at > '2022-02-08T13:15:45.000Z'"
+      const expected = "select 1 from user where created_at > '2022-02-08T13:15:45.000'"
       expect(format(query, [new Date(ts)])).toEqual(expected)
     })
 

--- a/src/sanitization.ts
+++ b/src/sanitization.ts
@@ -44,7 +44,7 @@ function sanitize(value: Value): string {
   }
 
   if (value instanceof Date) {
-    return quote(value.toISOString())
+    return quote(value.toISOString().replace('Z', ''))
   }
 
   return quote(value.toString())


### PR DESCRIPTION
Including the `Z` timezone works in select statements but throws an "incorrect datetime value" error during insert. Strip the timezone from the string before using it as a parameter replacement value.