### PR TITLE
Add options for returning rows from queries as an array or object

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -163,6 +163,40 @@ describe('execute', () => {
     expect(got2).toEqual(want)
   })
 
+  test('it properly returns and decodes a select query with rows as array when designated', async () => {
+    const mockResponse = {
+      session: mockSession,
+      result: {
+        fields: [{ name: ':vtg1', type: 'INT32' }],
+        rows: [{ lengths: ['1'], values: 'MQ==' }]
+      }
+    }
+
+    const want: ExecutedQuery = {
+      headers: [':vtg1'],
+      types: { ':vtg1': 'INT32' },
+      rows: [[1]],
+      size: 1,
+      statement: 'SELECT 1 from dual;',
+      time: 1,
+      rowsAffected: null,
+      insertId: null
+    }
+
+    mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
+      expect(opts.headers['authorization']).toMatch(/Basic /)
+      const bodyObj = JSON.parse(opts.body.toString())
+      expect(bodyObj.session).toEqual(null)
+      return mockResponse
+    })
+
+    const connection = connect(config)
+    const got = await connection.execute('SELECT 1 from dual;', null, { as: 'array' })
+    got.time = 1
+
+    expect(got).toEqual(want)
+  })
+
   test('it properly returns an executed query for a DDL statement', async () => {
     const mockResponse = {
       session: mockSession,

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -129,6 +129,7 @@ describe('execute', () => {
     const want: ExecutedQuery = {
       headers: [':vtg1'],
       types: { ':vtg1': 'INT32' },
+      fields: [{ name: ':vtg1', type: 'INT32' }],
       rows: [{ ':vtg1': 1 }],
       size: 1,
       statement: 'SELECT 1 from dual;',
@@ -176,6 +177,7 @@ describe('execute', () => {
       headers: [':vtg1'],
       types: { ':vtg1': 'INT32' },
       rows: [[1]],
+      fields: [{ name: ':vtg1', type: 'INT32' }],
       size: 1,
       statement: 'SELECT 1 from dual;',
       time: 1,
@@ -209,6 +211,7 @@ describe('execute', () => {
     const want: ExecutedQuery = {
       headers: [],
       types: {},
+      fields: [],
       rows: [],
       rowsAffected: null,
       insertId: null,
@@ -238,6 +241,7 @@ describe('execute', () => {
     const want: ExecutedQuery = {
       headers: [],
       types: {},
+      fields: [],
       rows: [],
       rowsAffected: 1,
       insertId: null,
@@ -268,6 +272,7 @@ describe('execute', () => {
     const want: ExecutedQuery = {
       headers: [],
       types: {},
+      fields: [],
       rows: [],
       rowsAffected: 1,
       insertId: '2',
@@ -352,6 +357,7 @@ describe('execute', () => {
       headers: [':vtg1'],
       rows: [{ ':vtg1': 1 }],
       types: { ':vtg1': 'INT32' },
+      fields: [{ name: ':vtg1', type: 'INT32' }],
       size: 1,
       insertId: null,
       rowsAffected: null,
@@ -384,6 +390,7 @@ describe('execute', () => {
     const want: ExecutedQuery = {
       headers: [':vtg1'],
       types: { ':vtg1': 'INT32' },
+      fields: [{ name: ':vtg1', type: 'INT32' }],
       rows: [{ ':vtg1': 1 }],
       size: 1,
       insertId: null,
@@ -417,6 +424,7 @@ describe('execute', () => {
     const want: ExecutedQuery = {
       headers: [':vtg1'],
       types: { ':vtg1': 'INT64' },
+      fields: [{ name: ':vtg1', type: 'INT64' }],
       rows: [{ ':vtg1': BigInt(1) }],
       size: 1,
       insertId: null,
@@ -453,6 +461,7 @@ describe('execute', () => {
     const want: ExecutedQuery = {
       headers: ['document'],
       types: { document: 'JSON' },
+      fields: [{ name: 'document', type: 'JSON' }],
       rows: [{ document: JSON.parse(document) }],
       size: 1,
       insertId: null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,6 +280,7 @@ export function connect(config: Config): Connection {
 
 function parseArrayRow(fields: Field[], rawRow: QueryResultRow, cast: Cast): Row {
   const row = decodeRow(rawRow)
+
   return fields.map((field, ix) => {
     return cast(field, row[ix])
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ type ExecuteOptions = {
   as?: ExecuteAs
 }
 
-type ExecuteArgs = object | Array<unknown> | null
+type ExecuteArgs = object | any[] | null
 
 const defaultExecuteOptions: ExecuteOptions = {
   as: 'object'

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export interface ExecutedQuery {
   headers: string[]
   types: Types
   rows: Row[]
+  fields: Field[]
   size: number
   statement: string
   insertId: string | null
@@ -215,15 +216,17 @@ export class Connection {
 
     this.session = session
 
+    const fields = result?.fields ?? []
     const rows = result ? parse(result, this.config.cast || cast, options.as) : []
-    const headers = result ? result.fields?.map((f) => f.name) ?? [] : []
+    const headers = fields.map((f) => f.name)
 
     const typeByName = (acc, { name, type }) => ({ ...acc, [name]: type })
-    const types = result ? result.fields?.reduce<Types>(typeByName, {}) ?? {} : {}
+    const types = fields.reduce<Types>(typeByName, {})
 
     return {
       headers,
       types,
+      fields,
       rows,
       rowsAffected,
       insertId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ interface QueryResult {
 type ExecuteAs = 'array' | 'object'
 
 type ExecuteOptions = {
-  as: ExecuteAs
+  as?: ExecuteAs
 }
 
 type ExecuteArgs = object | Array<unknown> | null
@@ -217,7 +217,7 @@ export class Connection {
     this.session = session
 
     const fields = result?.fields ?? []
-    const rows = result ? parse(result, this.config.cast || cast, options.as) : []
+    const rows = result ? parse(result, this.config.cast || cast, options.as || 'object') : []
     const headers = fields.map((f) => f.name)
 
     const typeByName = (acc, { name, type }) => ({ ...acc, [name]: type })


### PR DESCRIPTION
Before this pull request, we only returned the rows from a query as an object. This led to a problem where if you have two columns with the same name, the last instance of it would overwrite the value, leading to loss of data. This fixes this issue by taking a note from MySQL in Ruby and allowing the users to return the results as an array, fixing this issue. Additionally, we are returning all of the fields back with executed queries, because that data will line up to the rows when it's executed.