### PR TITLE
Better support for NULLs

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -121,22 +121,19 @@ describe('execute', () => {
     const mockResponse = {
       session: mockSession,
       result: {
-        fields: [
-          { name: ':vtg1', type: 'INT32' },
-          { name: 'null' },
-        ],
+        fields: [{ name: ':vtg1', type: 'INT32' }, { name: 'null' }],
         rows: [{ lengths: ['1', '-1'], values: 'MQ==' }]
       }
     }
 
     const want: ExecutedQuery = {
       headers: [':vtg1', 'null'],
-      types: { ':vtg1': 'INT32', 'null': 'NULL' },
+      types: { ':vtg1': 'INT32', null: 'NULL' },
       fields: [
         { name: ':vtg1', type: 'INT32' },
-        { name: 'null', type: 'NULL' },
+        { name: 'null', type: 'NULL' }
       ],
-      rows: [{ ':vtg1': 1, 'null': null }],
+      rows: [{ ':vtg1': 1, null: null }],
       size: 1,
       statement: 'SELECT 1, null from dual;',
       time: 1,
@@ -174,20 +171,16 @@ describe('execute', () => {
     const mockResponse = {
       session: mockSession,
       result: {
-        fields: [
-          { name: 'null' },
-        ],
-        rows: [{ lengths: ['-1']}]
+        fields: [{ name: 'null' }],
+        rows: [{ lengths: ['-1'] }]
       }
     }
 
     const want: ExecutedQuery = {
       headers: ['null'],
-      types: { 'null': 'NULL' },
-      fields: [
-        { name: 'null', type: 'NULL' },
-      ],
-      rows: [{ 'null': null }],
+      types: { null: 'NULL' },
+      fields: [{ name: 'null', type: 'NULL' }],
+      rows: [{ null: null }],
       size: 1,
       statement: 'SELECT null',
       time: 1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,7 +222,9 @@ export class Connection {
     // NULL due to the protojson spec. NULL in our enum
     // is 0, and empty fields are omitted from the JSON response,
     // so we should backfill an expected type.
-    fields.forEach((f) => { f.type = f.type || 'NULL' })
+    fields.forEach((f) => {
+      f.type = f.type || 'NULL'
+    })
 
     const rows = result ? parse(result, this.config.cast || cast, options.as || 'object') : []
     const headers = fields.map((f) => f.name)

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ interface QueryResultRow {
 
 export interface Field {
   name: string
-  type?: string
+  type: string
   table?: string
 
   // Only populated for included fields
@@ -222,9 +222,9 @@ export class Connection {
     // NULL due to the protojson spec. NULL in our enum
     // is 0, and empty fields are omitted from the JSON response,
     // so we should backfill an expected type.
-    fields.forEach((f) => {
-      f.type = f.type || 'NULL'
-    })
+    for (const field of fields) {
+      field.type ||= 'NULL'
+    }
 
     const rows = result ? parse(result, this.config.cast || cast, options.as || 'object') : []
     const headers = fields.map((f) => f.name)


### PR DESCRIPTION
In general, both bugs fixed here are the result of protojson encoding and fields being omitted from the JSON response:

In the case of a NULL column, the NULL type is omitted from the types enum becasue it's numeric value is "0", and protojson omits this due to it being a default value.

In the case of `select null`, we get another edge case, where the `values` itself is entirely omitted due to it being an empty sequence of bytes. This case is exaggerated for sure, but it is likely to happen if an entire row is simply 1 column of NULL, or even multiple NULLs. So something like, `select foo from table` may yield if too if `foo` is allowed to be NULL.

Fixes #72