### PR TITLE
Better timing information for queries

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -123,7 +123,8 @@ describe('execute', () => {
       result: {
         fields: [{ name: ':vtg1', type: 'INT32' }, { name: 'null' }],
         rows: [{ lengths: ['1', '-1'], values: 'MQ==' }]
-      }
+      },
+      timing: 1000
     }
 
     const want: ExecutedQuery = {
@@ -150,7 +151,6 @@ describe('execute', () => {
 
     const connection = connect(config)
     const got = await connection.execute('SELECT 1, null from dual;')
-    got.time = 1
 
     expect(got).toEqual(want)
 
@@ -173,7 +173,8 @@ describe('execute', () => {
       result: {
         fields: [{ name: 'null' }],
         rows: [{ lengths: ['-1'] }]
-      }
+      },
+      timing: 1000
     }
 
     const want: ExecutedQuery = {
@@ -197,7 +198,6 @@ describe('execute', () => {
 
     const connection = connect(config)
     const got = await connection.execute('SELECT null')
-    got.time = 1
 
     expect(got).toEqual(want)
 
@@ -220,7 +220,8 @@ describe('execute', () => {
       result: {
         fields: [{ name: ':vtg1', type: 'INT32' }],
         rows: [{ lengths: ['1'], values: 'MQ==' }]
-      }
+      },
+      timing: 1000
     }
 
     const want: ExecutedQuery = {
@@ -244,7 +245,6 @@ describe('execute', () => {
 
     const connection = connect(config)
     const got = await connection.execute('SELECT 1 from dual;', null, { as: 'array' })
-    got.time = 1
 
     expect(got).toEqual(want)
   })
@@ -252,7 +252,8 @@ describe('execute', () => {
   test('it properly returns an executed query for a DDL statement', async () => {
     const mockResponse = {
       session: mockSession,
-      result: {}
+      result: {},
+      timing: 0
     }
 
     mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, mockResponse)
@@ -267,12 +268,11 @@ describe('execute', () => {
       insertId: null,
       size: 0,
       statement: query,
-      time: 1
+      time: 0
     }
 
     const connection = connect(config)
     const got = await connection.execute(query)
-    got.time = 1
 
     expect(got).toEqual(want)
   })
@@ -282,7 +282,8 @@ describe('execute', () => {
       session: mockSession,
       result: {
         rowsAffected: '1'
-      }
+      },
+      timing: 1000
     }
 
     mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, mockResponse)
@@ -302,7 +303,6 @@ describe('execute', () => {
 
     const connection = connect(config)
     const got = await connection.execute(query)
-    got.time = 1
 
     expect(got).toEqual(want)
   })
@@ -313,7 +313,8 @@ describe('execute', () => {
       result: {
         rowsAffected: '1',
         insertId: '2'
-      }
+      },
+      timing: 1000
     }
 
     mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, mockResponse)
@@ -333,7 +334,6 @@ describe('execute', () => {
 
     const connection = connect(config)
     const got = await connection.execute(query)
-    got.time = 1
 
     expect(got).toEqual(want)
   })
@@ -400,7 +400,8 @@ describe('execute', () => {
       result: {
         fields: [{ name: ':vtg1', type: 'INT32' }],
         rows: [{ lengths: ['1'], values: 'MQ==' }]
-      }
+      },
+      timing: 1000
     }
 
     const want: ExecutedQuery = {
@@ -423,7 +424,6 @@ describe('execute', () => {
 
     const connection = connect(config)
     const got = await connection.execute('SELECT ? from dual where foo = ?;', [1, 'bar'])
-    got.time = 1
 
     expect(got).toEqual(want)
   })
@@ -434,7 +434,8 @@ describe('execute', () => {
       result: {
         fields: [{ name: ':vtg1', type: 'INT32' }],
         rows: [{ lengths: ['1'], values: 'MQ==' }]
-      }
+      },
+      timing: 1000
     }
 
     const want: ExecutedQuery = {
@@ -457,7 +458,6 @@ describe('execute', () => {
 
     const connection = connect({ ...config, format: SqlString.format })
     const got = await connection.execute('select ?? from ?? where id = ?', [['login', 'email'], 'users', 42])
-    got.time = 1
 
     expect(got).toEqual(want)
   })
@@ -468,7 +468,8 @@ describe('execute', () => {
       result: {
         fields: [{ name: ':vtg1', type: 'INT64' }],
         rows: [{ lengths: ['1'], values: 'MQ==' }]
-      }
+      },
+      timing: 1000
     }
 
     const want: ExecutedQuery = {
@@ -492,7 +493,6 @@ describe('execute', () => {
     const inflate = (field, value) => (field.type === 'INT64' ? BigInt(value) : value)
     const connection = connect({ ...config, cast: inflate })
     const got = await connection.execute('select 1 from dual')
-    got.time = 1
 
     expect(got).toEqual(want)
   })
@@ -505,7 +505,8 @@ describe('execute', () => {
       result: {
         fields: [{ name: 'document', type: 'JSON' }],
         rows: [{ lengths: [String(document.length)], values: btoa(document) }]
-      }
+      },
+      timing: 1000
     }
 
     const want: ExecutedQuery = {
@@ -528,7 +529,6 @@ describe('execute', () => {
 
     const connection = connect(config)
     const got = await connection.execute('select document from documents')
-    got.time = 1
 
     expect(got).toEqual(want)
   })

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -124,7 +124,7 @@ describe('execute', () => {
         fields: [{ name: ':vtg1', type: 'INT32' }, { name: 'null' }],
         rows: [{ lengths: ['1', '-1'], values: 'MQ==' }]
       },
-      timing: 1000
+      timing: 1
     }
 
     const want: ExecutedQuery = {
@@ -137,9 +137,9 @@ describe('execute', () => {
       rows: [{ ':vtg1': 1, null: null }],
       size: 1,
       statement: 'SELECT 1, null from dual;',
-      time: 1,
       rowsAffected: null,
-      insertId: null
+      insertId: null,
+      time: 1000
     }
 
     mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
@@ -162,7 +162,6 @@ describe('execute', () => {
     })
 
     const got2 = await connection.execute('SELECT 1, null from dual;')
-    got2.time = 1
 
     expect(got2).toEqual(want)
   })
@@ -174,7 +173,7 @@ describe('execute', () => {
         fields: [{ name: 'null' }],
         rows: [{ lengths: ['-1'] }]
       },
-      timing: 1000
+      timing: 1
     }
 
     const want: ExecutedQuery = {
@@ -184,9 +183,9 @@ describe('execute', () => {
       rows: [{ null: null }],
       size: 1,
       statement: 'SELECT null',
-      time: 1,
       rowsAffected: null,
-      insertId: null
+      insertId: null,
+      time: 1000
     }
 
     mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
@@ -209,7 +208,6 @@ describe('execute', () => {
     })
 
     const got2 = await connection.execute('SELECT null')
-    got2.time = 1
 
     expect(got2).toEqual(want)
   })
@@ -221,7 +219,7 @@ describe('execute', () => {
         fields: [{ name: ':vtg1', type: 'INT32' }],
         rows: [{ lengths: ['1'], values: 'MQ==' }]
       },
-      timing: 1000
+      timing: 1
     }
 
     const want: ExecutedQuery = {
@@ -231,7 +229,7 @@ describe('execute', () => {
       fields: [{ name: ':vtg1', type: 'INT32' }],
       size: 1,
       statement: 'SELECT 1 from dual;',
-      time: 1,
+      time: 1000,
       rowsAffected: null,
       insertId: null
     }
@@ -283,7 +281,7 @@ describe('execute', () => {
       result: {
         rowsAffected: '1'
       },
-      timing: 1000
+      timing: 1
     }
 
     mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, mockResponse)
@@ -298,7 +296,7 @@ describe('execute', () => {
       insertId: null,
       size: 0,
       statement: query,
-      time: 1
+      time: 1000
     }
 
     const connection = connect(config)
@@ -314,7 +312,7 @@ describe('execute', () => {
         rowsAffected: '1',
         insertId: '2'
       },
-      timing: 1000
+      timing: 1
     }
 
     mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, mockResponse)
@@ -329,7 +327,7 @@ describe('execute', () => {
       insertId: '2',
       size: 0,
       statement: query,
-      time: 1
+      time: 1000
     }
 
     const connection = connect(config)
@@ -401,7 +399,7 @@ describe('execute', () => {
         fields: [{ name: ':vtg1', type: 'INT32' }],
         rows: [{ lengths: ['1'], values: 'MQ==' }]
       },
-      timing: 1000
+      timing: 1
     }
 
     const want: ExecutedQuery = {
@@ -413,7 +411,7 @@ describe('execute', () => {
       insertId: null,
       rowsAffected: null,
       statement: "SELECT 1 from dual where foo = 'bar';",
-      time: 1
+      time: 1000
     }
 
     mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
@@ -435,7 +433,7 @@ describe('execute', () => {
         fields: [{ name: ':vtg1', type: 'INT32' }],
         rows: [{ lengths: ['1'], values: 'MQ==' }]
       },
-      timing: 1000
+      timing: 1
     }
 
     const want: ExecutedQuery = {
@@ -447,7 +445,7 @@ describe('execute', () => {
       insertId: null,
       rowsAffected: null,
       statement: 'select `login`, `email` from `users` where id = 42',
-      time: 1
+      time: 1000
     }
 
     mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
@@ -469,7 +467,7 @@ describe('execute', () => {
         fields: [{ name: ':vtg1', type: 'INT64' }],
         rows: [{ lengths: ['1'], values: 'MQ==' }]
       },
-      timing: 1000
+      timing: 1
     }
 
     const want: ExecutedQuery = {
@@ -481,7 +479,7 @@ describe('execute', () => {
       insertId: null,
       rowsAffected: null,
       statement: 'select 1 from dual',
-      time: 1
+      time: 1000
     }
 
     mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
@@ -506,7 +504,7 @@ describe('execute', () => {
         fields: [{ name: 'document', type: 'JSON' }],
         rows: [{ lengths: [String(document.length)], values: btoa(document) }]
       },
-      timing: 1000
+      timing: 1
     }
 
     const want: ExecutedQuery = {
@@ -518,7 +516,7 @@ describe('execute', () => {
       insertId: null,
       rowsAffected: null,
       statement: 'select document from documents',
-      time: 1
+      time: 1000
     }
 
     mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,7 +241,7 @@ export class Connection {
       insertId,
       size: rows.length,
       statement: sql,
-      time: timingSeconds / 1000
+      time: timingSeconds * 1000
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,7 @@ interface QueryExecuteResponse {
   session: QuerySession
   result: QueryResult | null
   error?: VitessError
+  timing?: number // duration in seconds
 }
 
 interface QueryResult {
@@ -202,11 +203,9 @@ export class Connection {
     const formatter = this.config.format || format
     const sql = args ? formatter(query, args) : query
 
-    const start = Date.now()
     const saved = await postJSON<QueryExecuteResponse>(this.config, url, { query: sql, session: this.session })
-    const time = Date.now() - start
 
-    const { result, session, error } = saved
+    const { result, session, error, timing } = saved
     if (error) {
       throw new DatabaseError(error.message, 400, error)
     }
@@ -231,6 +230,7 @@ export class Connection {
 
     const typeByName = (acc, { name, type }) => ({ ...acc, [name]: type })
     const types = fields.reduce<Types>(typeByName, {})
+    const timingSeconds = timing ?? 0
 
     return {
       headers,
@@ -241,7 +241,7 @@ export class Connection {
       insertId,
       size: rows.length,
       statement: sql,
-      time
+      time: timingSeconds / 1000
     }
   }
 


### PR DESCRIPTION
We've changed things so that we can return timing information from our API service which is more accurate than what we're using here. This way, we get something closest to the query execution time without the overhead.