### PR TITLE
Cast as execute option

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,41 @@ const config = {
 const conn = connect(config)
 ```
 
+You can also pass a custom `cast` function to `execute`. If present, this will override the `cast` function set by the connection:
+
+```ts
+import { connect, cast } from '@planetscale/database'
+
+function connectionInflate(field, value) {
+  if (field.type === 'INT64' || field.type === 'UINT64') {
+    return BigInt(value)
+  }
+  return cast(field, value)
+}
+
+const config = {
+  cast: connectionInflate,
+  host: '<host>',
+  username: '<user>',
+  password: '<password>'
+}
+
+const conn = connect(config)
+
+const result = await conn.execute(
+  'SELECT userId, SUM(balance) AS balance FROM UserBalanceItem GROUP BY userId',
+  {},
+  {
+    cast: (field, value) => {
+      if (field.name === 'balance') {
+        return BigInt(value)
+      }
+      return cast(field, value)
+    }
+  }
+)
+```
+
 ### Row return values
 
 Rows can be returned as an object or an array of column values by passing an `as` option to `execute`.

--- a/README.md
+++ b/README.md
@@ -156,24 +156,6 @@ const conn = connect(config)
 You can also pass a custom `cast` function to `execute`. If present, this will override the `cast` function set by the connection:
 
 ```ts
-import { connect, cast } from '@planetscale/database'
-
-function connectionInflate(field, value) {
-  if (field.type === 'INT64' || field.type === 'UINT64') {
-    return BigInt(value)
-  }
-  return cast(field, value)
-}
-
-const config = {
-  cast: connectionInflate,
-  host: '<host>',
-  username: '<user>',
-  password: '<password>'
-}
-
-const conn = connect(config)
-
 const result = await conn.execute(
   'SELECT userId, SUM(balance) AS balance FROM UserBalanceItem GROUP BY userId',
   {},

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -511,8 +511,8 @@ describe('execute', () => {
       fields: [{ name: ':vtg1', type: 'INT64' }],
       rows: [{ ':vtg1': 'I am a biggish int' }],
       size: 1,
-      insertId: null,
-      rowsAffected: null,
+      insertId: '0',
+      rowsAffected: 0,
       statement: 'select 1 from dual',
       time: 1000
     }
@@ -525,7 +525,7 @@ describe('execute', () => {
     const connInflate = (field, value) => (field.type === 'INT64' ? 'I am a biggish int' : value)
     const inflate = (field, value) => (field.type === 'INT64' ? BigInt(value) : value)
     const connection = connect({ ...config, cast: inflate })
-    const got = await connection.execute('select 1 from dual', {}, {cast: connInflate})
+    const got = await connection.execute('select 1 from dual', {}, { cast: connInflate })
 
     expect(got).toEqual(want)
   })

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -495,6 +495,41 @@ describe('execute', () => {
     expect(got).toEqual(want)
   })
 
+  test('uses custom cast function when it is passed to execute', async () => {
+    const mockResponse = {
+      session: null,
+      result: {
+        fields: [{ name: ':vtg1', type: 'INT64' }],
+        rows: [{ lengths: ['1'], values: 'MQ==' }]
+      },
+      timing: 1
+    }
+
+    const want: ExecutedQuery = {
+      headers: [':vtg1'],
+      types: { ':vtg1': 'INT64' },
+      fields: [{ name: ':vtg1', type: 'INT64' }],
+      rows: [{ ':vtg1': 'I am a biggish int' }],
+      size: 1,
+      insertId: null,
+      rowsAffected: null,
+      statement: 'select 1 from dual',
+      time: 1000
+    }
+
+    mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
+      const bodyObj = JSON.parse(opts.body.toString())
+      expect(bodyObj.query).toEqual(want.statement)
+      return mockResponse
+    })
+    const connInflate = (field, value) => (field.type === 'INT64' ? 'I am a biggish int' : value)
+    const inflate = (field, value) => (field.type === 'INT64' ? BigInt(value) : value)
+    const connection = connect({ ...config, cast: inflate })
+    const got = await connection.execute('select 1 from dual', {}, {cast: connInflate})
+
+    expect(got).toEqual(want)
+  })
+
   test('parses json column values', async () => {
     const document = JSON.stringify({ answer: 42 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ interface QueryResult {
 type ExecuteAs = 'array' | 'object'
 
 type ExecuteOptions = {
-  as?: ExecuteAs,
+  as?: ExecuteAs
   cast?: Cast
 }
 
@@ -199,10 +199,6 @@ export class Connection {
     args: ExecuteArgs = null,
     options: ExecuteOptions = defaultExecuteOptions
   ): Promise<ExecutedQuery> {
-
-    // needed because we're adding the cast option...
-    options = {...defaultExecuteOptions, ...options}
-
     const url = new URL('/psdb.v1alpha1.Database/Execute', `https://${this.config.host}`)
 
     const formatter = this.config.format || format
@@ -230,7 +226,8 @@ export class Connection {
       field.type ||= 'NULL'
     }
 
-    const rows = result ? parse(result, options.cast || this.config.cast || cast, options.as || 'object') : []
+    const castFn = options.cast || this.config.cast || cast
+    const rows = result ? parse(result, castFn, options.as || 'object') : []
     const headers = fields.map((f) => f.name)
 
     const typeByName = (acc, { name, type }) => ({ ...acc, [name]: type })

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,8 @@ interface QueryResult {
 type ExecuteAs = 'array' | 'object'
 
 type ExecuteOptions = {
-  as?: ExecuteAs
+  as?: ExecuteAs,
+  cast?: Cast
 }
 
 type ExecuteArgs = object | any[] | null
@@ -198,6 +199,10 @@ export class Connection {
     args: ExecuteArgs = null,
     options: ExecuteOptions = defaultExecuteOptions
   ): Promise<ExecutedQuery> {
+
+    // needed because we're adding the cast option...
+    options = {...defaultExecuteOptions, ...options}
+
     const url = new URL('/psdb.v1alpha1.Database/Execute', `https://${this.config.host}`)
 
     const formatter = this.config.format || format
@@ -225,7 +230,7 @@ export class Connection {
       field.type ||= 'NULL'
     }
 
-    const rows = result ? parse(result, this.config.cast || cast, options.as || 'object') : []
+    const rows = result ? parse(result, options.cast || this.config.cast || cast, options.as || 'object') : []
     const headers = fields.map((f) => f.name)
 
     const typeByName = (acc, { name, type }) => ({ ...acc, [name]: type })


### PR DESCRIPTION
Implements #80, i.e. adding `cast` optionally to `ExecuteOptions`:

```ts
const result = connOrTx.execute(query, values, { as: 'object',  cast: myOneOffCastFn })
```

Notes:
- I don't believe this is a breaking change. 
- I added a test & all the tests pass.



