### PR TITLE
coerce rowsAffected and insertId to concrete values

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -137,8 +137,8 @@ describe('execute', () => {
       rows: [{ ':vtg1': 1, null: null }],
       size: 1,
       statement: 'SELECT 1, null from dual;',
-      rowsAffected: null,
-      insertId: null,
+      rowsAffected: 0,
+      insertId: '0',
       time: 1000
     }
 
@@ -183,8 +183,8 @@ describe('execute', () => {
       rows: [{ null: null }],
       size: 1,
       statement: 'SELECT null',
-      rowsAffected: null,
-      insertId: null,
+      rowsAffected: 0,
+      insertId: '0',
       time: 1000
     }
 
@@ -230,8 +230,8 @@ describe('execute', () => {
       size: 1,
       statement: 'SELECT 1 from dual;',
       time: 1000,
-      rowsAffected: null,
-      insertId: null
+      rowsAffected: 0,
+      insertId: '0'
     }
 
     mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
@@ -262,8 +262,8 @@ describe('execute', () => {
       types: {},
       fields: [],
       rows: [],
-      rowsAffected: null,
-      insertId: null,
+      rowsAffected: 0,
+      insertId: '0',
       size: 0,
       statement: query,
       time: 0
@@ -293,7 +293,7 @@ describe('execute', () => {
       fields: [],
       rows: [],
       rowsAffected: 1,
-      insertId: null,
+      insertId: '0',
       size: 0,
       statement: query,
       time: 1000
@@ -408,8 +408,8 @@ describe('execute', () => {
       types: { ':vtg1': 'INT32' },
       fields: [{ name: ':vtg1', type: 'INT32' }],
       size: 1,
-      insertId: null,
-      rowsAffected: null,
+      insertId: '0',
+      rowsAffected: 0,
       statement: "SELECT 1 from dual where foo = 'bar';",
       time: 1000
     }
@@ -442,8 +442,8 @@ describe('execute', () => {
       fields: [{ name: ':vtg1', type: 'INT32' }],
       rows: [{ ':vtg1': 1 }],
       size: 1,
-      insertId: null,
-      rowsAffected: null,
+      insertId: '0',
+      rowsAffected: 0,
       statement: 'select `login`, `email` from `users` where id = 42',
       time: 1000
     }
@@ -476,8 +476,8 @@ describe('execute', () => {
       fields: [{ name: ':vtg1', type: 'INT64' }],
       rows: [{ ':vtg1': BigInt(1) }],
       size: 1,
-      insertId: null,
-      rowsAffected: null,
+      insertId: '0',
+      rowsAffected: 0,
       statement: 'select 1 from dual',
       time: 1000
     }
@@ -513,8 +513,8 @@ describe('execute', () => {
       fields: [{ name: 'document', type: 'JSON' }],
       rows: [{ document: JSON.parse(document) }],
       size: 1,
-      insertId: null,
-      rowsAffected: null,
+      insertId: '0',
+      rowsAffected: 0,
       statement: 'select document from documents',
       time: 1000
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,8 @@ export interface ExecutedQuery {
   fields: Field[]
   size: number
   statement: string
-  insertId: string | null
-  rowsAffected: number | null
+  insertId: string
+  rowsAffected: number
   time: number
 }
 
@@ -210,8 +210,8 @@ export class Connection {
       throw new DatabaseError(error.message, 400, error)
     }
 
-    const rowsAffected = result?.rowsAffected ? parseInt(result.rowsAffected, 10) : null
-    const insertId = result?.insertId ?? null
+    const rowsAffected = result?.rowsAffected ? parseInt(result.rowsAffected, 10) : 0
+    const insertId = result?.insertId ?? '0'
 
     this.session = session
 


### PR DESCRIPTION
The fact that they come over the wire as null is a side effect of the protojson encoding, when these fields are uint64 and can't actually be null. An empty value should be treated as an equivalent "empty" value when inflating.

The side effect of this is making rowsAffected and lastId not nullable anymore on ExecutedQuery.

The slightly weird part about this is both rowsAffected and lastId are uint64 (a bigint), but rowsAffected is being lossily coerced into a JavaScript number, while lastId is left as a string.

I don't know if we should address being able to coerce things into a BigInt when it's applicable or not. I don't know how JavaScript ecosystem works.

Fixes #88