### PR TITLE
Return geometry as its raw value.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -359,6 +359,7 @@ export function cast(field: Field, value: string | null): any {
     case 'BIT':
     case 'VARBINARY':
     case 'BINARY':
+    case 'GEOMETRY':
       return value
     case 'JSON':
       return JSON.parse(decode(value))


### PR DESCRIPTION
As mentioned in #98, in order to properly return geometry values, we have to return it's raw values and let users handle it on their own. This takes away the step of needing to have a custom casting function for users using geometry data.