### PR TITLE
feat: include formatted sql on DatabaseError for improved debugging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,13 @@ interface VitessError {
 export class DatabaseError extends Error {
   body: VitessError
   status: number
-  constructor(message: string, status: number, body: VitessError) {
+  sql?: string
+  constructor(message: string, status: number, body: VitessError, sql?: string) {
     super(message)
     this.status = status
     this.name = 'DatabaseError'
     this.body = body
+    this.sql = sql
   }
 }
 
@@ -213,7 +215,7 @@ export class Connection {
     }
 
     if (error) {
-      throw new DatabaseError(error.message, 400, error)
+      throw new DatabaseError(error.message, 400, error, sql)
     }
 
     const rowsAffected = result?.rowsAffected ? parseInt(result.rowsAffected, 10) : 0


### PR DESCRIPTION
# What?
Adds an optional `sql` field to the `DatabaseError` which gets populated with the formatted sql statement in `execute()` if a database error is encountered (not errors rising from the postJSON function).

# Why?
Today while writing an application using this driver, I ran into `syntax error at position XXXX` on a pretty big generated SQL query with user provided values (`?`). Debugging this in my code editor alone was quite tough, so I decided to open up DataGrip and pasted my generated query into its console for help. No luck. Syntax errors everywhere due to all the placeholder question marks. As a last resort, I dug into my `node_modules` folder and added `console.log(sql)` into `execute()` and got the full query that way. Pasted it into DataGrip, and bingo, it showed me exactly where the error was.

Point is, that was way more difficult than it needed to be. In that situation it would have been really awesome to just `console.log(error.sql)`, or just a more general debug log option (future PR perhaps?)

Added a test for it as well so should be ready to merge if maintainers feel it's an appropriate addition.