### PR TITLE
Allow insecure URLs with config option

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import { cast, connect, format, hex, ExecutedQuery, DatabaseError } from '../dis
 import { fetch, MockAgent, setGlobalDispatcher } from 'undici'
 import packageJSON from '../package.json'
 
-const mockHosts = ['https://example.com', 'https://localhost', 'http://localhost:3000']
+const mockHosts = ['https://example.com', 'http://localhost:3000']
 
 const CREATE_SESSION_PATH = '/psdb.v1alpha1.Database/CreateSession'
 const EXECUTE_PATH = '/psdb.v1alpha1.Database/Execute'

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -40,27 +40,6 @@ describe('config', () => {
     const got = await connection.execute('SELECT 1 from dual;')
     expect(got).toBeDefined()
   })
-
-  test('parses insecure url when allowed', async () => {
-    const mockResponse = {
-      session: mockSession,
-      result: { fields: [], rows: [] }
-    }
-
-    mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
-      expect(opts.headers['Authorization']).toEqual(`Basic ${btoa('someuser:password')}`)
-      expect(opts.headers['User-Agent']).toEqual(`database-js/${packageJSON.version}`)
-      return mockResponse
-    })
-
-    const connection = connect({
-      fetch,
-      url: 'http://someuser:password@localhost:3000',
-      allowInsecureConnection: true
-    })
-    const got = await connection.execute('SELECT 1 from dual;')
-    expect(got).toBeDefined()
-  })
 })
 
 describe('transaction', () => {
@@ -585,6 +564,70 @@ describe('execute', () => {
     const got = await connection.execute('select document from documents')
 
     expect(got).toEqual(want)
+  })
+
+  test('properly executes a query with an insecure connection URL', async () => {
+    const mockResponse = {
+      session: mockSession,
+      result: { fields: [], rows: [] }
+    }
+
+    mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
+      expect(opts.headers['Authorization']).toEqual(`Basic ${btoa('someuser:password')}`)
+      expect(opts.headers['User-Agent']).toEqual(`database-js/${packageJSON.version}`)
+      return mockResponse
+    })
+
+    const connection = connect({
+      fetch,
+      url: 'http://someuser:password@localhost:3000',
+      allowInsecureConnection: true
+    })
+    const got = await connection.execute('SELECT 1 from dual;')
+    expect(got).toBeDefined()
+  })
+
+  test('properly executes a query with allowInsecureConnection true and also with a custom port specified', async () => {
+    const mockResponse = {
+      session: mockSession,
+      result: { fields: [], rows: [] }
+    }
+
+    mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
+      expect(opts.headers['Authorization']).toEqual(`Basic ${btoa('someuser:password')}`)
+      expect(opts.headers['User-Agent']).toEqual(`database-js/${packageJSON.version}`)
+      return mockResponse
+    })
+
+    const connection = connect({
+      ...config,
+      allowInsecureConnection: true,
+      host: 'localhost',
+      port: 3000
+    })
+    const got = await connection.execute('SELECT 1 from dual;')
+    expect(got).toBeDefined()
+  })
+
+  test('ignores the port when using with a secure connection', async () => {
+    const mockResponse = {
+      session: mockSession,
+      result: { fields: [], rows: [] }
+    }
+
+    mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
+      expect(opts.headers['Authorization']).toEqual(`Basic ${btoa('someuser:password')}`)
+      expect(opts.headers['User-Agent']).toEqual(`database-js/${packageJSON.version}`)
+      return mockResponse
+    })
+
+    const connection = connect({
+      ...config,
+      port: 3000
+    })
+
+    const got = await connection.execute('SELECT 1 from dual;')
+    expect(got).toBeDefined()
   })
 })
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import { cast, connect, format, hex, ExecutedQuery, DatabaseError } from '../dis
 import { fetch, MockAgent, setGlobalDispatcher } from 'undici'
 import packageJSON from '../package.json'
 
-const mockHosts = ['https://example.com', 'http://localhost:3000']
+const mockHosts = ['https://example.com', 'https://localhost', 'http://localhost:3000']
 
 const CREATE_SESSION_PATH = '/psdb.v1alpha1.Database/CreateSession'
 const EXECUTE_PATH = '/psdb.v1alpha1.Database/Execute'
@@ -41,7 +41,7 @@ describe('config', () => {
     expect(got).toBeDefined()
   })
 
-  test('parses localhost url', async () => {
+  test('parses insecure url when allowed', async () => {
     const mockResponse = {
       session: mockSession,
       result: { fields: [], rows: [] }
@@ -53,7 +53,11 @@ describe('config', () => {
       return mockResponse
     })
 
-    const connection = connect({ fetch, url: 'http://someuser:password@localhost:3000' })
+    const connection = connect({
+      fetch,
+      url: 'http://someuser:password@localhost:3000',
+      allowInsecureConnection: true
+    })
     const got = await connection.execute('SELECT 1 from dual;')
     expect(got).toBeDefined()
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ export interface Config {
   username?: string
   password?: string
   host?: string
+  allowInsecureConnection?: boolean
   fetch?: (input: string, init?: Req) => Promise<Res>
   format?: (query: string, args: any) => string
   cast?: Cast
@@ -178,8 +179,10 @@ export class Connection {
       this.config.password = url.password
       this.config.host = url.hostname
 
-      protocol = url.protocol.startsWith('http') ? url.protocol : protocol
-      port = url.port
+      if (this.config.allowInsecureConnection) {
+        protocol = url.protocol.startsWith('http') ? url.protocol : protocol
+        port = url.port
+      }
     }
 
     this.url = new URL(`${protocol}//${this.config.host}${port ? `:${port}` : ''}`)


### PR DESCRIPTION
As per the discussion over in #135 , this adds an `allowInsecureConnection` option to the `connect()` method that allows the use of `http` as protocol when explicitly set to `true`.