### PR TITLE
Respect `config.url` as source of truth for API calls

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -3,8 +3,7 @@ import { cast, connect, format, hex, ExecutedQuery, DatabaseError } from '../dis
 import { fetch, MockAgent, setGlobalDispatcher } from 'undici'
 import packageJSON from '../package.json'
 
-const mockHost = 'https://example.com'
-
+const mockHosts = ['http://localhost:8080', 'https://example.com']
 const CREATE_SESSION_PATH = '/psdb.v1alpha1.Database/CreateSession'
 const EXECUTE_PATH = '/psdb.v1alpha1.Database/Execute'
 const config = {
@@ -20,7 +19,7 @@ mockAgent.disableNetConnect()
 setGlobalDispatcher(mockAgent)
 
 // Provide the base url to the request
-const mockPool = mockAgent.get(mockHost)
+const mockPool = mockAgent.get((value) => mockHosts.includes(value))
 const mockSession = 42
 
 describe('config', () => {
@@ -37,6 +36,23 @@ describe('config', () => {
     })
 
     const connection = connect({ fetch, url: 'mysql://someuser:password@example.com' })
+    const got = await connection.execute('SELECT 1 from dual;')
+    expect(got).toBeDefined()
+  })
+
+  test('parses database URL when using HTTP', async () => {
+    const mockResponse = {
+      session: mockSession,
+      result: { fields: [], rows: [] }
+    }
+
+    mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
+      expect(opts.headers['Authorization']).toEqual(`Basic ${btoa('someuser:password')}`)
+      expect(opts.headers['User-Agent']).toEqual(`database-js/${packageJSON.version}`)
+      return mockResponse
+    })
+
+    const connection = connect({ fetch, url: 'http://someuser:password@localhost:8080' })
     const got = await connection.execute('SELECT 1 from dual;')
     expect(got).toBeDefined()
   })


### PR DESCRIPTION
This pull request updates our driver to use `config.url` as the source of truth for the base URL of our API calls. The way this was set up before, we could only make these calls to the production API. Some users have been mocking out the Edge API locally, so this gives users a means of working with Edge locally without needing to introduce an `insecure` flag into the driver.

Closes https://github.com/planetscale/database-js/pull/136 https://github.com/planetscale/database-js/issues/135