### PR TITLE
fix: Malformed interface Field

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ export interface Field {
   charset?: number | null
   flags?: number | null
   columnType?: string | null
+  decimals?: number | null
 }
 
 type QuerySession = unknown


### PR DESCRIPTION
This ought to fix https://github.com/planetscale/database-js/issues/148.

Added decimal property.

I confirm object in v1.11.0.
```
fields: [
    {
      name: 'stars',
      type: 'FLOAT32',
      table: 'hotels',
      orgTable: 'hotels',
      database: 'for_vitest',
      orgName: 'stars',
      columnLength: 12,
      charset: 63,
      decimals: 31,
      flags: 32768
    }
  ],
```

