### PR TITLE
feat: change to generic type for ExecutedQuery

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -580,6 +580,67 @@ describe('execute', () => {
     const got = await connection.execute('select document from documents')
 
     expect(got).toEqual(want)
+    expect(got.rows[0].document).toEqual(want.rows[0].document)
+  })
+
+  test('allows setting the type of rows in the query results', async () => {
+    const mockResponse = {
+      session: mockSession,
+      result: {
+        fields: [{ name: ':vtg1', type: 'INT32' }, { name: 'null' }],
+        rows: [{ lengths: ['1', '-1'], values: 'MQ==' }]
+      },
+      timing: 1
+    }
+
+    const want: ExecutedQuery = {
+      headers: [':vtg1', 'null'],
+      types: { ':vtg1': 'INT32', null: 'NULL' },
+      fields: [
+        { name: ':vtg1', type: 'INT32' },
+        { name: 'null', type: 'NULL' }
+      ],
+      rows: [{ ':vtg1': 1, null: null }],
+      size: 1,
+      statement: 'SELECT 1, null from dual;',
+      rowsAffected: 0,
+      insertId: '0',
+      time: 1000
+    }
+
+    interface Got {
+      ':vtg1'?: number
+      null?: null
+    }
+
+    const isGot = (object: any): object is Got => {
+      return ':vtg1' in object && 'null' in object
+    }
+
+    mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
+      expect(opts.headers['Authorization']).toMatch(/Basic /)
+      const bodyObj = JSON.parse(opts.body.toString())
+      expect(bodyObj.session).toEqual(null)
+      return mockResponse
+    })
+
+    const connection = connect(config)
+    const got: ExecutedQuery<Got> = await connection.execute('SELECT 1, null from dual;')
+
+    expect(got).toEqual(want)
+    expect(isGot(got.rows[0])).toBe(true)
+
+    mockPool.intercept({ path: EXECUTE_PATH, method: 'POST' }).reply(200, (opts) => {
+      expect(opts.headers['Authorization']).toMatch(/Basic /)
+      const bodyObj = JSON.parse(opts.body.toString())
+      expect(bodyObj.session).toEqual(mockSession)
+      return mockResponse
+    })
+
+    const got2: ExecutedQuery<Got> = await connection.execute('SELECT 1, null from dual;')
+
+    expect(got2).toEqual(want)
+    expect(isGot(got2.rows[0])).toBe(true)
   })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export { hex } from './text.js'
 import { decode } from './text.js'
 import { Version } from './version.js'
 
-type Row = Record<string, any> | any[]
+type Row<T = Record<string, any> | any[]> = T
 
 interface VitessError {
   message: string
@@ -24,10 +24,10 @@ export class DatabaseError extends Error {
 
 type Types = Record<string, string>
 
-export interface ExecutedQuery {
+export interface ExecutedQuery<T = any> {
   headers: string[]
   types: Types
-  rows: Row[]
+  rows: Row<T>[]
   fields: Field[]
   size: number
   statement: string


### PR DESCRIPTION
This ought to fix https://github.com/planetscale/database-js/issues/150.

This change allows you to define a type for an object if you have an array of rows generated as an `'object'`.
As a result, properties will be suggested as described in the [issue](https://github.com/planetscale/database-js/issues/150), and you will not have to access properties for `any`.

I don't think we will have to worry about the ESLint error `Unsafe member access .id on an `any` value.`(https://typescript-eslint.io/rules/no-unsafe-member-access/).