### PR TITLE
Expose `config` as a public property

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -57,14 +57,16 @@ describe('config', () => {
     expect(got).toBeDefined()
   })
 
-  test('exposes database url', async () => {
-    const connection = connect({ fetch, url: 'mysql://someuser:password@example.com' })
-    expect(connection.connectionUrl).toBe('mysql://someuser:password@example.com')
-  })
-
-  test('exposes database url', async () => {
+  test('exposes config as a public field', async () => {
+    const config = { url: 'mysql://someuser:password@example.com/db' }
     const connection = connect(config)
-    expect(connection.connectionUrl).toBe('https://example.com/')
+    expect(connection.config).toEqual({
+      fetch: expect.any(Function),
+      host: 'example.com',
+      username: 'someuser',
+      password: 'password',
+      url: 'mysql://someuser:password@example.com/db'
+    })
   })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ type ExecuteAs = 'array' | 'object'
 type ExecuteArgs = object | any[] | null
 
 export class Client {
-  private config: Config
+  public readonly config: Config
 
   constructor(config: Config) {
     this.config = config
@@ -135,10 +135,6 @@ export class Client {
 
   connection(): Connection {
     return new Connection(this.config)
-  }
-
-  get connectionUrl() {
-    return getUrlFromConfig(this.config)
   }
 }
 
@@ -180,12 +176,8 @@ function buildURL(url: URL): string {
   return new URL(url.pathname, `${scheme}${url.host}`).toString()
 }
 
-function getUrlFromConfig(config: Config): string {
-  return config.url ?? new URL(`https://${config.host}`).toString()
-}
-
 export class Connection {
-  private config: Config
+  public readonly config: Config
   private session: QuerySession | null
   private url: string
 
@@ -291,10 +283,6 @@ export class Connection {
       statement: sql,
       time: timingSeconds * 1000
     }
-  }
-
-  get connectionUrl() {
-    return getUrlFromConfig(this.config)
   }
 
   private async createSession(): Promise<QuerySession> {


### PR DESCRIPTION
In Prisma's driver adapter for Planetscale, we need to be able to get database name from the connection string. Currently, url is not exposed as a public property. In this PR we solve this by exposing `config` object that we get from user through constructor.
