### PR TITLE
feat(sanitization): support `bigint` params by not wrapping them in quotes

### DIFF
--- a/__tests__/sanitization.test.ts
+++ b/__tests__/sanitization.test.ts
@@ -36,6 +36,12 @@ describe('sanitization', () => {
       expect(format(query, [12, 42])).toEqual(expected)
     })
 
+    test('formats bigint values', () => {
+      const query = 'select 1 from user where id=? and id2=? and id3=?'
+      const expected = 'select 1 from user where id=12 and id2=42 and id3=9223372036854775807'
+      expect(format(query, [12n, 42n, 9223372036854775807n])).toEqual(expected)
+    })
+
     test('formats string values', () => {
       const query = 'select 1 from user where state=?'
       const expected = "select 1 from user where state='active'"

--- a/src/sanitization.ts
+++ b/src/sanitization.ts
@@ -27,7 +27,7 @@ function sanitize(value: Value): string {
     return 'null'
   }
 
-  if (typeof value === 'number') {
+  if (['number', 'bigint'].includes(typeof value)) {
     return String(value)
   }
 


### PR DESCRIPTION
Hi 👋🏻, Alberto from @prisma here.

This PR fixes a surprising behavior we at @prisma found while adding new tests for an [internal PR](https://github.com/prisma/prisma-engines/pull/4648) related to our new [Driver Adapters](https://planetscale.com/docs/tutorials/planetscale-serverless-driver-prisma-example) feature.

We noticed that the JavaScript PlanetScale driver currently doesn't support `bigint` query parameters: these parameters are treated as strings by the client-side sanitization routine, causing SQL syntax errors at runtime.
For instance, `SELECT * FROM user LIMIT ?` with parameters `[1n]` is validated as `SELECT * FROM user LIMIT '1'`, which of course results in a SQL error.

Here is the relevant output of `pnpm test` after adding [this new test](https://github.com/planetscale/database-js/commit/5b91c6216f8ef6b8ce7c73b3cc610804833cead1):

```
 FAIL  __tests__/sanitization.test.ts
  ● sanitization › format › formats bigint values

    expect(received).toEqual(expected) // deep equality

    Expected: "select 1 from user where id=12 and id2=42 and id3=9223372036854775807"
    Received: "select 1 from user where id='12' and id2='42' and id3='9223372036854775807'"

      40 |       const query = 'select 1 from user where id=? and id2=? and id3=?'
      41 |       const expected = 'select 1 from user where id=12 and id2=42 and id3=9223372036854775807'
    > 42 |       expect(format(query, [12n, 42n, 9223372036854775807n])).toEqual(expected)
         |                                                               ^
      43 |     })
      44 |
      45 |     test('formats string values', () => {

      at Object.<anonymous> (__tests__/sanitization.test.ts:42:63)
```

If [we apply](https://github.com/planetscale/database-js/commit/10d94ac8f0034ec5f02999ef48b67c34c541c1ae) the same sanitization logic currently applied on `number` query parameters, the tests pass.

```
 PASS  __tests__/sanitization.test.ts
 PASS  __tests__/index.test.ts
 PASS  __tests__/text.test.ts

Test Suites: 3 passed, 3 total
Tests:       54 passed, 54 total
Snapshots:   0 total
Time:        0.604 s, estimated 1 s
Ran all test suites
```

---

I'm of course available for feedback concerning this PR :)