### PR TITLE
Set use statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,13 @@
       ],
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-empty-function": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
       "@typescript-eslint/ban-ts-comment": "off"
     },
     "root": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,11 @@ export interface Config {
   cast?: Cast
 }
 
+type Session = {
+  database?: string
+  variables?: Variables
+}
+
 interface QueryResultRow {
   lengths: string[]
   values?: string
@@ -123,8 +128,8 @@ export class Client {
     this.config = config
   }
 
-  async transaction<T>(fn: (tx: Transaction) => Promise<T>, override?: Config): Promise<T> {
-    return this.connection().transaction(fn, override)
+  async transaction<T>(fn: (tx: Transaction) => Promise<T>, override?: Session): Promise<T> {
+    return this.connection(override).transaction(fn)
   }
 
   async execute<T = Row<'object'>>(
@@ -145,7 +150,7 @@ export class Client {
     return this.connection().execute<T>(query, args, options)
   }
 
-  connection(override?: Config): Connection {
+  connection(override?: Session): Connection {
     return new Connection({ ...this.config, ...override })
   }
 }
@@ -210,7 +215,7 @@ export class Connection {
     }
   }
 
-  async transaction<T>(fn: (tx: Transaction) => Promise<T>, override?: Config): Promise<T> {
+  async transaction<T>(fn: (tx: Transaction) => Promise<T>, override?: Session): Promise<T> {
     const conn = new Connection({ ...this.config, ...override }) // Create a new connection specifically for the transaction
     const tx = new Tx(conn)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,8 @@ type Res = {
 
 export type Cast = typeof cast
 type Format = typeof format
-type Variables = Record<string, any>
+type Variable = '@@boost_cached_queries'
+type Variables = Record<Variable, string>
 
 export interface Config {
   url?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,7 +180,8 @@ class Tx {
     args: ExecuteArgs = null,
     options: any = { as: 'object' }
   ): Promise<ExecutedQuery<T>> {
-    return this.conn.execute<T>(query, args, options)
+    const { database: _, variables: __, ...executeOptions } = options
+    return this.conn.execute<T>(query, args, executeOptions)
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,12 +168,12 @@ class Tx {
   async execute<T = Row<'object'>>(
     query: string,
     args?: ExecuteArgs,
-    options?: ExecuteOptions<'object'>
+    options?: Omit<ExecuteOptions<'object'>, keyof Session>
   ): Promise<ExecutedQuery<T>>
   async execute<T = Row<'array'>>(
     query: string,
     args: ExecuteArgs,
-    options: ExecuteOptions<'array'>
+    options: Omit<ExecuteOptions<'array'>, keyof Session>
   ): Promise<ExecutedQuery<T>>
   async execute<T = Row<'object'> | Row<'array'>>(
     query: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,6 @@ type Res = {
 
 export type Cast = typeof cast
 type Format = typeof format
-type Use = string
 
 export interface Config {
   url?: string
@@ -92,7 +91,7 @@ type QuerySession = unknown
 
 type QuerySessionOptions = {
   set?: Record<string, any>
-  use?: Use
+  use?: string
 }
 
 interface QueryExecuteResponse {
@@ -114,10 +113,12 @@ type ExecuteAs = 'array' | 'object'
 type ExecuteArgs = Record<string, any> | any[] | null
 
 type ExecuteOptions<T extends ExecuteAs = 'object'> = T extends 'array'
-  ? { as?: 'object'; cast?: Cast; use?: Use }
+  ? { as?: 'object'; cast?: Cast }
   : T extends 'object'
-  ? { as: 'array'; cast?: Cast; use?: Use }
+  ? { as: 'array'; cast?: Cast }
   : never
+
+type ClientExecuteOptions<T extends ExecuteAs = 'object'> = ExecuteOptions<T> & QuerySessionOptions
 
 export class Client {
   public readonly config: Config
@@ -133,12 +134,12 @@ export class Client {
   async execute<T = Row<'object'>>(
     query: string,
     args?: ExecuteArgs,
-    options?: ExecuteOptions<'object'>
+    options?: ClientExecuteOptions<'object'>
   ): Promise<ExecutedQuery<T>>
   async execute<T = Row<'array'>>(
     query: string,
     args: ExecuteArgs,
-    options: ExecuteOptions<'array'>
+    options: ClientExecuteOptions<'array'>
   ): Promise<ExecutedQuery<T>>
   async execute<T = Row<'object'> | Row<'array'>>(
     query: string,


### PR DESCRIPTION
**What**

Add first class support for [`USE`](https://dev.mysql.com/doc/refman/8.0/en/use.html) and [`SET`](https://dev.mysql.com/doc/refman/8.0/en/set-statement.html) statements.

**Why**

We want to make it easier to correctly use PlanetScale over HTTP supporting some of more exotic features (boost, replicas, sharding)

**How**

You can define which database to use, or which variables to set as part of `Config`. This means you can pass this onto: `connect()`, `Client#new`, `Client#connection`, `Connection#new` and `Connection#execute()`.

**Config defaults and overrides**

```js
// `connect`

connect({ url }).execute('select 1 from dual')
// defaults { database: undefined, variables: undefined }
// overrides { database: undefined, variables: undefined }

connect({ url }).execute('select 1 from dual', [], { database: '@replica' })
// defaults { database: undefined, variables: undefined }
// overrides { database: '@replica', variables: undefined }

connect({ url, database: 'keyspace' }).execute('select 1 from dual')
// defaults { database: 'keyspace', variables: undefined }
// overrides { database: undefined, variables: undefined }

connect({ url, database: 'keyspace' }).execute('select 1 from dual', [], { database: '@replica' })
// defaults { database: 'keyspace', variables: undefined }
// overrides { database: '@replica', variables: undefined }



// `new Client

new Client({ url }).execute('select 1 from dual')
// defaults { database: undefined, variables: undefined }
// overrides { database: undefined, variables: undefined }

new Client().execute('select 1 from dual', [], { database: '@replica' })
// defaults { database: undefined, variables: undefined }
// overrides { database: '@replica', variables: undefined }

new Client({ url, database: 'keyspace' }).execute('select 1 from dual')
// defaults { database: 'keyspace', variables: undefined }
// overrides { database: undefined, variables: undefined }

new Client({ url, database: 'keyspace' }).execute('select 1 from dual', { database: '@replica' })
// defaults { database: 'keyspace', variables: undefined }
// overrides { database: '@replica', variables: undefined }



// `new Client#connection`

new Client({ url }).connection().execute('select 1 from dual')
// defaults { database: undefined, variables: undefined }
// overrides { database: undefined, variables: undefined }

new Client().connection().execute('select 1 from dual', [], { database: '@replica' })
// defaults { database: undefined, variables: undefined }
// overrides { database: '@replica', variables: undefined }

new Client({ url, database: 'keyspace' }).connection().execute('select 1 from dual')
// defaults { database: 'keyspace', variables: undefined }
// overrides { database: undefined, variables: undefined }

new Client({ url, database: 'keyspace' }).connection().execute('select 1 from dual', { database: '@replica' })
// defaults { database: 'keyspace', variables: undefined }
// overrides { database: '@replica', variables: undefined }

new Client({ url }).connection({ database: 'otherkeyspace' }).execute('select 1 from dual')
// defaults { database: 'otherkeyspace', variables: undefined }
// overrides { database: undefined, variables: undefined }

new Client().connection({ database: 'otherkeyspace' }).execute('select 1 from dual', [], { database: '@replica' })
// defaults { database: 'otherkeyspace', variables: undefined }
// overrides { database: '@replica', variables: undefined }

new Client({ url, database: 'keyspace' }).connection({ database: 'otherkeyspace' }).execute('select 1 from dual')
// defaults { database: 'otherkeyspace', variables: undefined }
// overrides { database: undefined, variables: undefined }

new Client({ url, database: 'keyspace' }).connection({ database: 'otherkeyspace' }).execute('select 1 from dual', { database: '@replica' })
// defaults { database: 'otherkeyspace', variables: undefined }
// overrides { database: '@replica', variables: undefined }
```