### PR TITLE
Encode a Buffer as hexadecimal

### DIFF
--- a/src/sanitization.ts
+++ b/src/sanitization.ts
@@ -47,6 +47,10 @@ function sanitize(value: Value): string {
     return quote(value.toISOString().slice(0, -1))
   }
 
+  if (value instanceof Buffer) {
+    return `0x${value.toString('hex')}`
+  }
+
   return quote(value.toString())
 }
 


### PR DESCRIPTION
This handles better for BLOB type columns. Without this, it basically would have only worked for ASCII binary data since it gets Buffer.toString()'d, but then does an extra quoting and sanitization pass.

For binary data, which we can assume is coming from a Buffer, we want to send as hexadecimal.

Fixes #161