### PR TITLE
Fix formatting empty Uint8Arrays

### DIFF
--- a/__tests__/sanitization.test.ts
+++ b/__tests__/sanitization.test.ts
@@ -80,6 +80,12 @@ describe('sanitization', () => {
       expect(format(query, [state])).toEqual(expected)
     })
 
+    test('formats empty Uint8Array', () => {
+      const query = 'select 1 from user where state = ?'
+      const expected = "select 1 from user where state = x''"
+      expect(format(query, [new Uint8Array([])])).toEqual(expected)
+    })
+
     test('escapes double quotes', () => {
       const query = 'select 1 from user where state = ?'
       const expected = 'select 1 from user where state = \'\\"a\\"\''

--- a/__tests__/text.test.ts
+++ b/__tests__/text.test.ts
@@ -42,7 +42,8 @@ describe('text', () => {
 
   describe('uint8ArrayToHex', () => {
     test('converts an array of 8-bit unsigned integers to hex', () => {
-      expect(uint8ArrayToHex(new Uint8Array([197]))).toEqual('0xc5')
+      expect(uint8ArrayToHex(new Uint8Array([]))).toEqual("x''")
+      expect(uint8ArrayToHex(new Uint8Array([197]))).toEqual("x'c5'")
     })
   })
 })

--- a/src/text.ts
+++ b/src/text.ts
@@ -15,7 +15,7 @@ export function uint8Array(text: string): Uint8Array {
 
 export function uint8ArrayToHex(uint8: Uint8Array): string {
   const digits = Array.from(uint8).map((i) => i.toString(16).padStart(2, '0'))
-  return `0x${digits.join('')}`
+  return `x'${digits.join('')}'`
 }
 
 function bytes(text: string): number[] {


### PR DESCRIPTION
Empty `Uint8Array`s are currently formatted as `0x` which isn't a hexadecimal literal so this uses the `x'...'` syntax instead of `0x...` so it's valid for an empty `Uint8Array`