### PR TITLE
Pin license finder

### DIFF
--- a/.github/workflows/licensing.yml
+++ b/.github/workflows/licensing.yml
@@ -17,5 +17,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: sudo gem install license_finder && npm install
+      - run: sudo gem install license_finder -v 7.1
+      - run: npm install
       - run: license_finder


### PR DESCRIPTION
License finder 7.2 has some [differences](https://github.com/pivotal/LicenseFinder/blob/master/CHANGELOG.md#720--2024-05-07) with 7.1. Lock to old version to unblock deploying to main