### PR TITLE
feat: add `isClient` guard

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import SqlString from 'sqlstring'
-import { connect, format, hex, DatabaseError, type Cast } from '../dist/index'
+import { connect, format, hex, DatabaseError, type Cast, Client, isClient } from '../dist/index'
 import { fetch, MockAgent, setGlobalDispatcher } from 'undici'
 import packageJSON from '../package.json'
 
@@ -614,5 +614,12 @@ describe('format', () => {
 describe('hex', () => {
   test('exports hex function', () => {
     expect(hex('\0')).toEqual('0x00')
+  })
+})
+
+describe('guards', () => {
+  test('isClient', () => {
+    const client = new Client(config)
+    expect(isClient(client)).toBe(true)
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,10 +115,17 @@ type ExecuteOptions<T extends ExecuteAs = 'object'> = T extends 'array'
   ? { as: 'array'; cast?: Cast }
   : never
 
+export const TypeId: unique symbol = Symbol.for('@planetscale/database/Client')
+export type TypeId = typeof TypeId
+
+export const isClient = (u: unknown): u is Client => typeof u === 'object' && u !== null && TypeId in u
+
 export class Client {
-  public readonly config: Config
+  public readonly config: Config;
+  readonly [TypeId]: TypeId
 
   constructor(config: Config) {
+    this[TypeId] = TypeId
     this.config = config
   }
 


### PR DESCRIPTION
Hey there,

Small little utility guard for checking if a client is a PlanetScale client. We currently have a helper like this in our codebase
```ts
function isPlanetScaleClient(client: unknown): client is PlanetScale.Client {
  return (
    Predicate.isRecord(client) &&
    Predicate.isRecord(client.config) &&
    Predicate.isFunction(client.transaction) &&
    Predicate.isFunction(client.execute) &&
    Predicate.isFunction(client.connection)
  );
}
```
due to some issues with `instanceof` check unexpectedly returning false.

Accept or deny as you wish :)