### PR TITLE
Add a secure NPM configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+min-release-age=3
+allow-git=none
+ignore-scripts=true

--- a/package.json
+++ b/package.json
@@ -27,14 +27,10 @@
   },
   "scripts": {
     "clean": "rm -rf dist/",
-    "prebuild": "npm run clean",
-    "build": "tsc && tsc --module commonjs --outDir dist/cjs",
-    "postbuild": "echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json",
+    "build": "npm run clean && tsc && tsc --module commonjs --outDir dist/cjs && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json",
     "lint": "eslint src/ __tests__/",
-    "pretest": "npm run build",
-    "test": "jest",
-    "version": "echo \"export const Version = '$npm_package_version'\" > src/version.ts && git add src/version.ts && npm run build",
-    "prepublishOnly": "npm run build"
+    "test": "npm run build && jest",
+    "version": "echo \"export const Version = '$npm_package_version'\" > src/version.ts && git add src/version.ts && npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This sets up a `.npmrc` to require a minimum release age of 3 days for dependencies, [disallow git dependencies](https://github.blog/changelog/2026-02-18-npm-bulk-trusted-publishing-config-and-script-security-now-generally-available/), and ignore lifecycle scripts.

Disabling scripts is intended to prevent malicious postinstall scripts, but it has the side-effect of disabling existing defined [lifecycle scripts](https://docs.npmjs.com/cli/v11/using-npm/scripts) in our own `package.json`. Those have been manually replaced with the equivalent script calls.