### PR TITLE
Fix #144: Automatically strip port 3306 from connection strings

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -67,6 +67,16 @@ describe('config', () => {
     assert.notStrictEqual(got, undefined)
   })
 
+  test('strips port 3306 from database URL', async () => {
+    const connection = connect({ fetch, url: 'mysql://someuser:password@example.com:3306/db' })
+    assert.strictEqual(connection.config.host, 'example.com')
+  })
+
+  test('strips port 3306 from config.host', async () => {
+    const connection = connect({ fetch, host: 'example.com:3306', username: 'someuser', password: 'password' })
+    assert.strictEqual(connection.config.host, 'example.com')
+  })
+
   test('exposes config as a public field', async () => {
     const config = { url: 'mysql://someuser:password@example.com/db' }
     const connection = connect(config)

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,8 +204,9 @@ function protocol(protocol: string): string {
 
 function buildURL(url: URL): string {
   const scheme = `${protocol(url.protocol)}//`
+  const host = url.port === '3306' ? url.hostname : url.host
 
-  return new URL(url.pathname, `${scheme}${url.host}`).toString()
+  return new URL(url.pathname, `${scheme}${host}`).toString()
 }
 
 export class Connection {
@@ -226,6 +227,10 @@ export class Connection {
       this.config.host = url.hostname
       this.url = buildURL(url)
     } else {
+      const url = new URL(`https://${this.config.host}`)
+      if (url.port === '3306') {
+        this.config.host = url.hostname
+      }
       this.url = new URL(`https://${this.config.host}`).toString()
     }
   }


### PR DESCRIPTION
Closes #144

I updated the `buildURL` function in `src/index.ts` to automatically ignore `port 3306` when generating the connection URL if it's found in the `config.url`.

I also updated the Connection class constructor to strip 3306 directly from `config.host` if you pass the connection properties separately (e.g., host, username, password), coercing it properly to standard HTTPS (port 443).

I added a couple of test cases in `__tests__/index.test.ts` to verify that 3306 is properly stripped in both scenarios.